### PR TITLE
Add version(Windows)

### DIFF
--- a/source/aurora/directx/com.d
+++ b/source/aurora/directx/com.d
@@ -1,5 +1,7 @@
 module aurora.directx.com;
 
+version(Windows):
+
 public import core.sys.windows.windows;
 public import core.sys.windows.com;
 

--- a/source/aurora/directx/d2d1/d2d1_0.d
+++ b/source/aurora/directx/d2d1/d2d1_0.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1_0;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.dwrite;
 public import aurora.directx.dxgi;

--- a/source/aurora/directx/d2d1/d2d1_1.d
+++ b/source/aurora/directx/d2d1/d2d1_1.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1_1;
 
+version(Windows):
+
 public import aurora.directx.d3d.d3dcommon;
 public import aurora.directx.d2d1.d2d1_0;
 

--- a/source/aurora/directx/d2d1/d2d1_2.d
+++ b/source/aurora/directx/d2d1/d2d1_2.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1_2;
 
+version(Windows):
+
 public import aurora.directx.d2d1.d2d1_1;
 
 //

--- a/source/aurora/directx/d2d1/d2d1_3.d
+++ b/source/aurora/directx/d2d1/d2d1_3.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1_3;
 
+version(Windows):
+
 public import aurora.directx.d2d1.d2d1_2;
 public import aurora.directx.dwrite.dwrite_3;
 public import aurora.directx.d2d1.d2d1svg;

--- a/source/aurora/directx/d2d1/d2d1effectauthor_0.d
+++ b/source/aurora/directx/d2d1/d2d1effectauthor_0.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1effectauthor_0;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.d2d1.d2d1_1;
 

--- a/source/aurora/directx/d2d1/d2d1effectauthor_1.d
+++ b/source/aurora/directx/d2d1/d2d1effectauthor_1.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1effectauthor_1;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.d2d1.d2d1_3;
 public import aurora.directx.d2d1.d2d1effectauthor_0;

--- a/source/aurora/directx/d2d1/d2d1effects_0.d
+++ b/source/aurora/directx/d2d1/d2d1effects_0.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1effects_0;
 
+version(Windows):
+
 public import aurora.directx.com;
 
 public:

--- a/source/aurora/directx/d2d1/d2d1effects_1.d
+++ b/source/aurora/directx/d2d1/d2d1effects_1.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1effects_1;
 
+version(Windows):
+
 public import aurora.directx.d2d1.d2d1effects_0;
 
 public:

--- a/source/aurora/directx/d2d1/d2d1effects_2.d
+++ b/source/aurora/directx/d2d1/d2d1effects_2.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1effects_2;
 
+version(Windows):
+
 public import aurora.directx.d2d1.d2d1effects_1;
 
 public:

--- a/source/aurora/directx/d2d1/d2d1svg.d
+++ b/source/aurora/directx/d2d1/d2d1svg.d
@@ -1,5 +1,7 @@
 module aurora.directx.d2d1.d2d1svg;
 
+version(Windows):
+
 public import aurora.directx.d2d1.d2d1_2;
 
 public:

--- a/source/aurora/directx/d3d/d3dcommon.d
+++ b/source/aurora/directx/d3d/d3dcommon.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d.d3dcommon;
 
+version(Windows):
+
 public import aurora.directx.com;
 
 public:

--- a/source/aurora/directx/d3d/d3dcompiler.d
+++ b/source/aurora/directx/d3d/d3dcompiler.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d.d3dcompiler;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.d3d.d3dcommon;
 public import aurora.directx.d3d11.d3d11shader;

--- a/source/aurora/directx/d3d11/d3d11_0.d
+++ b/source/aurora/directx/d3d11/d3d11_0.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11_0;
 
+version(Windows):
+
 public import std.bitmanip;
 public import aurora.directx.com;
 public import aurora.directx.dxgi;

--- a/source/aurora/directx/d3d11/d3d11_1.d
+++ b/source/aurora/directx/d3d11/d3d11_1.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11_1;
 
+version(Windows):
+
 public import aurora.directx.d3d11.d3d11_0;
 
 public:

--- a/source/aurora/directx/d3d11/d3d11_2.d
+++ b/source/aurora/directx/d3d11/d3d11_2.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11_2;
 
+version(Windows):
+
 public import aurora.directx.d3d11.d3d11_1;
 
 public:

--- a/source/aurora/directx/d3d11/d3d11_3.d
+++ b/source/aurora/directx/d3d11/d3d11_3.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11_3;
 
+version(Windows):
+
 public import aurora.directx.d3d11.d3d11_2;
 
 public:

--- a/source/aurora/directx/d3d11/d3d11_4.d
+++ b/source/aurora/directx/d3d11/d3d11_4.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11_4;
 
+version(Windows):
+
 public import aurora.directx.d3d11.d3d11_3;
 
 public:

--- a/source/aurora/directx/d3d11/d3d11sdklayers.d
+++ b/source/aurora/directx/d3d11/d3d11sdklayers.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11sdklayers;
 
+version(Windows):
+
 import std.bitmanip;
 import aurora.directx.com;
 import aurora.directx.dxgi;

--- a/source/aurora/directx/d3d11/d3d11shader.d
+++ b/source/aurora/directx/d3d11/d3d11shader.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11shader;
 
+version(Windows):
+
 import std.bitmanip;
 import aurora.directx.com;
 import aurora.directx.d3d11;

--- a/source/aurora/directx/d3d11/d3d11shadertracing.d
+++ b/source/aurora/directx/d3d11/d3d11shadertracing.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d11.d3d11shadertracing;
 
+version(Windows):
+
 public import aurora.directx.d3d.d3dcommon;
 
 public:

--- a/source/aurora/directx/d3d11/d3dcsx.d
+++ b/source/aurora/directx/d3d11/d3dcsx.d
@@ -1,5 +1,7 @@
 ﻿module aurora.directx.d3d11.d3dcsx;
 
+version(Windows):
+
 import aurora.directx.com;
 import aurora.directx.dxgi;
 import aurora.directx.d3d11;

--- a/source/aurora/directx/d3d12/d3d12.d
+++ b/source/aurora/directx/d3d12/d3d12.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d12.d3d12;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.dxgi.dxgiformat;
 public import aurora.directx.dxgi.dxgicommon;

--- a/source/aurora/directx/d3d12/d3d12sdklayers.d
+++ b/source/aurora/directx/d3d12/d3d12sdklayers.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d12.d3d12sdklayers;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.d3d12.d3d12;
 

--- a/source/aurora/directx/d3d12/d3d12shader.d
+++ b/source/aurora/directx/d3d12/d3d12shader.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d12.d3d12shader;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.d3d.d3dcommon;
 

--- a/source/aurora/directx/d3d12/d3d12video.d
+++ b/source/aurora/directx/d3d12/d3d12video.d
@@ -1,5 +1,7 @@
 module aurora.directx.d3d12.d3d12video;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.dxgi.dxgicommon;
 public import aurora.directx.d3d12.d3d12;

--- a/source/aurora/directx/dwrite/dwrite_0.d
+++ b/source/aurora/directx/dwrite/dwrite_0.d
@@ -1,5 +1,7 @@
 module aurora.directx.dwrite.dwrite_0;
 
+version(Windows):
+
 public import std.bitmanip;
 public import aurora.directx.com;
 public import aurora.directx.d2d1;

--- a/source/aurora/directx/dwrite/dwrite_1.d
+++ b/source/aurora/directx/dwrite/dwrite_1.d
@@ -1,5 +1,7 @@
 module aurora.directx.dwrite.dwrite_1;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.dwrite.dwrite_0;
 

--- a/source/aurora/directx/dwrite/dwrite_2.d
+++ b/source/aurora/directx/dwrite/dwrite_2.d
@@ -1,5 +1,7 @@
 module aurora.directx.dwrite.dwrite_2;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.dwrite.dwrite_1;
 

--- a/source/aurora/directx/dwrite/dwrite_3.d
+++ b/source/aurora/directx/dwrite/dwrite_3.d
@@ -1,5 +1,7 @@
 module aurora.directx.dwrite.dwrite_3;
 
+version(Windows):
+
 public import aurora.directx.com;
 public import aurora.directx.dwrite.dwrite_2;
 

--- a/source/aurora/directx/dxgi/dxgi.d
+++ b/source/aurora/directx/dxgi/dxgi.d
@@ -1,5 +1,7 @@
 module aurora.directx.dxgi.dxgi;
 
+version(Windows):
+
 import aurora.directx.com;
 public import aurora.directx.dxgi.dxgitype;
 public import aurora.directx.dxgi.dxgicommon;

--- a/source/aurora/directx/dxgi/dxgi1_2.d
+++ b/source/aurora/directx/dxgi/dxgi1_2.d
@@ -1,5 +1,7 @@
 module aurora.directx.dxgi.dxgi1_2;
 
+version(Windows):
+
 import aurora.directx.com;
 public import aurora.directx.dxgi.dxgitype;
 public import aurora.directx.dxgi.dxgicommon;

--- a/source/aurora/directx/dxgi/dxgi1_3.d
+++ b/source/aurora/directx/dxgi/dxgi1_3.d
@@ -1,5 +1,7 @@
 module aurora.directx.dxgi.dxgi1_3;
 
+version(Windows):
+
 import aurora.directx.com;
 public import aurora.directx.dxgi.dxgitype;
 public import aurora.directx.dxgi.dxgicommon;

--- a/source/aurora/directx/dxgi/dxgi1_4.d
+++ b/source/aurora/directx/dxgi/dxgi1_4.d
@@ -1,5 +1,7 @@
 module aurora.directx.dxgi.dxgi1_4;
 
+version(Windows):
+
 import aurora.directx.com;
 public import aurora.directx.dxgi.dxgi1_3;
 

--- a/source/aurora/directx/dxgi/dxgi1_5.d
+++ b/source/aurora/directx/dxgi/dxgi1_5.d
@@ -1,5 +1,7 @@
 module aurora.directx.dxgi.dxgi1_5;
 
+version(Windows):
+
 import aurora.directx.com;
 public import aurora.directx.dxgi.dxgi1_4;
 

--- a/source/aurora/directx/dxgi/dxgi1_6.d
+++ b/source/aurora/directx/dxgi/dxgi1_6.d
@@ -1,5 +1,7 @@
 module aurora.directx.dxgi.dxgi1_6;
 
+version(Windows):
+
 import aurora.directx.com;
 public import aurora.directx.dxgi.dxgi1_5;
 

--- a/source/aurora/directx/wic.d
+++ b/source/aurora/directx/wic.d
@@ -1,5 +1,7 @@
 ﻿module aurora.directx.wic;
 
+version(Windows):
+
 import aurora.directx.com;
 
 alias uint WICColor;


### PR DESCRIPTION
This package depends on `core.sys.windows` which is entirely `version(Windows)` but is currently not annotated as such. Writing & configuring cross platform code becomes unnecessarily hard because dub does not support platform suffixes for dependencies (i.e. `"dependencies-windows":"aurora-directx"` doesn't work).

Essentially this PR makes the package compile on non-Windows systems so I don't have to fight with dub.